### PR TITLE
Update URLs in clusterhq-release.

### DIFF
--- a/clusterhq-release.spec
+++ b/clusterhq-release.spec
@@ -25,6 +25,7 @@ install -m 644 clusterhq.repo $RPM_BUILD_ROOT/etc/yum.repos.d
 %changelog
 * Fri Sep 11 2014 Tom Prince <tom.prince@clusterhq.com> - 1-4.fc20
 - Fix source repository URL.
+- Use https URLs.
 
 * Fri Aug 22 2014 Tom Prince <tom.prince@clusterhq.com> - 1-3.fc20
 - Disable GPG checks, since we don't have a signing key.

--- a/clusterhq.repo
+++ b/clusterhq.repo
@@ -1,11 +1,11 @@
 [clusterhq]
 name=ClusterHQ for Fedora $releasever
-baseurl=http://archive.clusterhq.com/fedora/$releasever/$basearch/
+baseurl=https://storage.googleapis.com/archive.clusterhq.com/fedora/$releasever/$basearch/
 enabled=1
 gpgcheck=0
 
 [clusterhq-source]
 name=ZFS on Linux for Fedora $releasever - Source
-baseurl=http://archive.clusterhq.com/fedora/$releasever/SRPMS/
+baseurl=https://storage.googleapis.com/archive.clusterhq.com/fedora/$releasever/SRPMS/
 enabled=0
 gpgcheck=0


### PR DESCRIPTION
Use HTTPS URLs and fix the source URL.

@lukemarsden was asking how to get the source RPMs. The answer is

``` shell
yum install https://storage.googleapis.com/archive.clusterhq.com/fedora/clusterhq-release$(rpm -E %dist).noarch.rpm
yumdownloader python-flocker
```

But I tried it and found that the URL was wrong.
